### PR TITLE
[Build] - build 관련 config 파일을 설정합니다.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  canipay-fe:
+    container_name: canipay-fe
+    image: woosang0430/canipay-fe:latest
+    environment:
+      - CANIPAY_ENV_API_URL=${NEXT_PUBLIC_BASE_API_URL}
+    ports:
+      - 3000:3000
+    restart: always

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,41 @@
+FROM node:18-alpine AS base
+
+FROM base AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+COPY package.json yarn.lock* ./
+RUN yarn --frozen-lockfile
+
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ENV NEXT_PUBLIC_BASE_API_URL=CANIPAY_ENV_API_URL
+
+RUN yarn run build
+
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+COPY ./env.sh /docker-entrypoint.d/env.sh
+RUN chmod +x /docker-entrypoint.d/env.sh
+
+USER nextjs
+
+EXPOSE 3000
+ENV PORT=3000
+
+ENV HOSTNAME="0.0.0.0"
+ENTRYPOINT ["/bin/sh", "-c", "/docker-entrypoint.d/env.sh && exec node server.js"]

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,9 @@
+for i in $(env | grep CANIPAY_ENV_)
+do
+  key=$(echo $i | cut -d '=' -f 1)
+  value=$(echo $i | cut -d '=' -f 2-)
+  echo $key=$value
+
+  # sed JS and CSS only
+  find /app/.next -type f \( -name '*.js' -o -name '*.css' \) -exec sed -i "s|${key}|${value}|g" '{}' +
+done

--- a/next.config.ts
+++ b/next.config.ts
@@ -28,6 +28,7 @@ const nextConfig: NextConfig = {
 
     return config;
   },
+  output: 'standalone',
   experimental: {
     turbo: {
       rules: {


### PR DESCRIPTION
### Issue number
- close #26

### Description
- ci 관련 config 파일을 추가합니다.
next의 dockerize를 참고하여 dockerfile을 만들었습니다. [참고링크](https://github.com/vercel/next.js/tree/canary/examples/with-docker)
- 프론트 환경변수를 docker 런타입에서 동적으로 설정되도록 설정합니다.

### Note
- docker 런타입 시 동적으로 환경변수를 설정하기 위해 next build 시 환경변수의 값은 특정 접두어(CANIPAY_ENV_)를 갖은 문자열로 설정됩니다.
- docker 런타입 시 env.sh 파일이 실행되어 next build된 파일에서 특정 접두어를 갖은 문자열을 런타입이 돌아가는 서버의 환경변수의 값으로 치환됩니다.