### PR TITLE
[Feature] - 결제 불가 UI 작업

### DIFF
--- a/src/components/stores/ReviewList.tsx
+++ b/src/components/stores/ReviewList.tsx
@@ -49,7 +49,7 @@ function ReviewList({ storeInfo }: ReviewListProps) {
       >
         리뷰 작성 하러가기
       </Button>
-      <ul className='flex h-full flex-col gap-3 overflow-auto pr-1'>
+      <ul className='flex h-full flex-col gap-3 overflow-auto pb-2 pr-1'>
         {reviewList.length === 0 ? (
           <li className='p-4'>
             <p className='text-center text-body-2'>

--- a/src/components/stores/StoreDetail.tsx
+++ b/src/components/stores/StoreDetail.tsx
@@ -62,7 +62,8 @@ function StoreDetail({ initStoreInfo }: StoreDetailProps) {
     <section
       className={twMerge(
         'fixed left-1/2 z-30 flex w-[90%] -translate-x-1/2 flex-col gap-5 overflow-auto rounded-sm bg-white p-4 shadow-500 duration-500',
-        storeInfo.paymentStatus === 'unregistered' ? 'top-[30%]' : 'inset-y-[15%]',
+        // NOTE: 사용자 디바이스 크기에 따라 height를 설정하기 위하여 inset-y 활용 (등록된 컴포넌트만 리뷰 목록이 존재하여 Height의 크기가 가변적)
+        storeInfo.paymentStatus === 'available' ? 'inset-y-[15%]' : 'top-[30%]',
         'md:left-[426px] md:top-[66px] md:w-[370px] md:translate-x-0',
         !asideToggle && 'md:-translate-x-[350px]'
       )}
@@ -102,9 +103,15 @@ function StoreDetail({ initStoreInfo }: StoreDetailProps) {
       {(() => {
         switch (storeInfo.paymentStatus) {
           case 'available':
-          case 'unavailable':
             return <ReviewList storeInfo={storeInfo} />;
-          default: // unregistered
+          case 'unavailable':
+            return (
+              <article>
+                <p className='text-caption-1 text-red'>결제 불가 매장</p>
+              </article>
+            );
+          // unregistered
+          default:
             return <RegisterStore storeInfo={storeInfo} updateStoreInfo={setStoreInfo} />;
         }
       })()}


### PR DESCRIPTION
### Issue number
- close #30

### Description
- 결제 불가 UI 작업을 수행하였습니다. -> 해당 UI가 크지 않고 별도의 비즈니스 로직이 들어가지 않아 별도의 컴포넌트로 분리하지 않았습니다.

<img width="809" alt="image" src="https://github.com/user-attachments/assets/58868f05-9e12-49d3-bedc-9b253d848006" />

### Note
- 리뷰의 더보기 버튼 클릭 시 floating 메뉴 렌더링 시 scroll이 생기는 이슈를 해결하기 위해 상위 ul 태그에 padding bottom을 추가하였습니다.
- 데스크탑 버전의 height를 지정하지 않고 inset-y, top 속성을 사용한 이유는 아래와 같습니다.
    1. top 속성 사용 이유: 상세 컴포넌트는 매장이 미등록, 결제 가능, 불가능일 때 렌더링 되며, **결제 불가능, 미등록의 경우는 컴포넌트의 높이가 고정적**이므로 페이지 기준 위에서 30% 에 위치하고 본인 자식의 height를 갖도록 하였습니다.
    2. inset-y 속성 사용 이유: 상세 컴포넌트에서 매장이 **결제 가능인 경우 리뷰 목록을 조회하고 스크롤 처리**를 해야합니다. 해당 서비스는 **데스크탑과 모바일을 지원**하므로 **디바이스 마다 높이**가 다르므로 높이를 지정하지 않고 **디바이스의 위아래 15%**를 남기고 나머지 영역을 차지할 수 있도록 처리하기 위해 inset-y 속성을 사용하였습니다.