### PR TITLE
[Feature] - 지도 Tooltip 위치 수정

### DIFF
--- a/src/components/maps/MapView.tsx
+++ b/src/components/maps/MapView.tsx
@@ -15,6 +15,7 @@ import { PaymentStatus, StoreInfo } from '@/types/store';
 import { useMapController } from '../contexts/MapControllerProvider';
 import MapContributors from './MapContributors';
 import MarkerToggleList from './MarkerToggleList';
+import StoreListTooltip from './StoreListTooltip';
 import StoreTooltip from './StoreTooltip';
 
 function MapView() {
@@ -123,13 +124,16 @@ function MapView() {
     }
   };
 
+  const singleSelectedStore = selectedStores.length === 1 ? selectedStores[0] : null;
+  const multipleSelectedStores = selectedStores.length > 1;
   return (
     <div id='map' className='relative size-full'>
       <MarkerToggleList />
       <MapContributors />
       <div id='map-tooltip' className='absolute'>
-        {selectedStores.length > 0 && (
-          <StoreTooltip stores={selectedStores} onSelectStore={onSelectStoreAtTooltip} />
+        {singleSelectedStore && <StoreTooltip storeId={selectedStores[0].id} />}
+        {multipleSelectedStores && (
+          <StoreListTooltip stores={selectedStores} onSelectStore={onSelectStoreAtTooltip} />
         )}
       </div>
     </div>

--- a/src/components/maps/MapView.tsx
+++ b/src/components/maps/MapView.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useParams, usePathname, useSearchParams } from 'next/navigation';
+import { Point } from 'ol/geom';
 import 'ol/ol.css';
+import { fromLonLat } from 'ol/proj';
 import { useEffect, useState } from 'react';
 import { LOCATION } from '@/constants/location';
 import { QUERY_STRING } from '@/constants/page';
@@ -90,7 +92,7 @@ function MapView() {
       paintStoreMarker(paymentDisabledStores, 'unavailable', 'red');
       paintStoreMarker(unregisteredStores, 'unregistered', 'gray');
 
-      clearEvent = controller.addMarkerClickEvent((event, features) => {
+      clearEvent = controller.addMarkerClickEvent((_, features) => {
         const selectedStores = features.map((feature) => {
           return {
             id: feature.get('id') as string,
@@ -99,8 +101,10 @@ function MapView() {
         });
 
         setSelectedStores(selectedStores);
-        controller.setOverlayLocation(event.coordinate);
-        controller.setCenter(event.coordinate);
+        const coordinate = (features[0].get('geometry') as Point).getCoordinates();
+
+        controller.setOverlayLocation(coordinate);
+        controller.setCenter(coordinate);
       });
     }
 
@@ -113,6 +117,8 @@ function MapView() {
     const targetStore = displayStoreList.find((store) => store.id === storeId);
 
     if (targetStore) {
+      // NOTE: 선택된 매장 위치로 이동
+      controller.setCenter(fromLonLat([+targetStore.lon, +targetStore.lat]));
       setSelectedStores([targetStore]);
     }
   };

--- a/src/components/maps/StoreListTooltip.tsx
+++ b/src/components/maps/StoreListTooltip.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+interface StoreListTooltipProps {
+  stores: {
+    id: string;
+    name: string;
+  }[];
+  onSelectStore: (storeId: string) => void;
+}
+
+function StoreListTooltip({ stores, onSelectStore }: StoreListTooltipProps) {
+  return (
+    <ul
+      role='menu'
+      className='absolute top-1 flex w-[80px] flex-col gap-1 rounded-sm bg-white p-1 text-caption-1 duration-200 hover:w-[140px]'
+    >
+      {stores.map((store) => {
+        return (
+          <li key={store.id} className='w-full overflow-auto'>
+            <button
+              type='button'
+              className='w-full truncate rounded-sm p-1 text-left duration-200 hover:bg-gray-200'
+              title={store.name}
+              onClick={() => onSelectStore(store.id)}
+            >
+              {store.name}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export default StoreListTooltip;

--- a/src/components/maps/StoreTooltip.tsx
+++ b/src/components/maps/StoreTooltip.tsx
@@ -5,17 +5,13 @@ import useStore from '@/hooks/react-query/useStore';
 import StoreItem from '../stores/StoreItem';
 
 interface StoreTooltipProps {
-  stores: {
-    id: string;
-    name: string;
-  }[];
-  onSelectStore: (storeId: string) => void;
+  storeId: string;
 }
 
-function StoreTooltip({ stores, onSelectStore }: StoreTooltipProps) {
-  const { data: storeInfo } = useStore(stores[0].id);
+function StoreTooltip({ storeId }: StoreTooltipProps) {
+  const { data: storeInfo } = useStore(storeId);
 
-  return stores.length === 1 ? (
+  return (
     <div className='absolute bottom-4 left-full w-[250px] -translate-x-1/2'>
       {storeInfo && (
         <>
@@ -24,26 +20,6 @@ function StoreTooltip({ stores, onSelectStore }: StoreTooltipProps) {
         </>
       )}
     </div>
-  ) : (
-    <ul
-      role='menu'
-      className='absolute top-1 flex w-[80px] flex-col gap-1 rounded-sm bg-white p-1 text-caption-1 duration-200 hover:w-[140px]'
-    >
-      {stores.map((store) => {
-        return (
-          <li key={store.id} className='w-full overflow-auto'>
-            <button
-              type='button'
-              className='w-full truncate rounded-sm p-1 text-left duration-200 hover:bg-gray-200'
-              title={store.name}
-              onClick={() => onSelectStore(store.id)}
-            >
-              {store.name}
-            </button>
-          </li>
-        );
-      })}
-    </ul>
   );
 }
 


### PR DESCRIPTION
### Issue number
- close #32

### Description
- 기존에는 지도의 툴팁 위치를 사용자가 마커를 클릭한 위치를 기준으로 렌더링을 지켰지만, 줌인을 하는 경우 툴팁의 위치가 어색하게 보여 매장의 위치로 조정하였습니다.
- 기존 매장 툴팁(StoreTooltop) 컴포넌트의 경우 선택된 매장이 한개일 경우에는 매장 정보를 간략하게 보여주고, 2개 이상인 경우 선택된 범위에 있는 매장 목록을 보여주는 2가지 일을 하고 있었지만, 해당 PR을 통해 각자 기능을 분리하기 위해 컴포넌트를 분리하였습니다.

as is
<img width="423" alt="Image" src="https://github.com/user-attachments/assets/c088fb8c-7b88-44d9-b247-ae261ddfc6ce" />

to be
<img width="367" alt="image" src="https://github.com/user-attachments/assets/90e786ef-c2ac-45ee-b330-9e3fbcb0115b" />


### Note
- 