### PR TITLE
[Chore] - release note 자동화 설정

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,60 @@
+name-template: "v$RESOLVED_VERSION 🌈"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: "🧰 Maintenance"
+    label: 
+      - "chore"
+      - "document"
+
+change-template: "- $TITLE (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+
+template: |
+  ## Changes
+
+  $CHANGES
+
+autolabeler:
+  - label: "chore"
+    branch:
+      - '/chore\/.+/'
+      - '/document\/.+/'
+    title:
+      - "/chore/i"
+      - "/document/i"
+  - label: "bug"
+    branch:
+      - '/fix\/.+/'
+      - '/hotfix\/.+/'
+      - '/bug\/.+/'
+    title:
+      - "/fix/i"
+      - "/hotfix/i"
+      - "/bug/i"
+  - label: "feature"
+    title:
+      - "/feature/i"
+    branch:
+      - '/feature\/.+/'

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,13 +1,11 @@
-name: Docker Image CI
+name: Docker CI Pipeline
 
 on:
-  push:
-    branches: [ "main" ]
+  release:
+    types: [published]
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     env:
@@ -15,22 +13,21 @@ jobs:
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
-  
-      - name: Login Dockerhub
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get latest release tag
+        id: get_release
+        run: echo "TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+
+      - name: Build the docker image
+        run: docker build . --file Dockerfile --tag $DOCKER_HUB_REPO/canipay-fe:latest
+
+      - name: Login docker hub
         run: echo "$DOCKER_HUB_TOKEN" | docker login --username $DOCKER_HUB_REPO --password-stdin
-
-      - name: auto increment tag
-        id: tag
-        uses: sophiware/actions-auto-increment-tag@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build the Docker image
-        run: docker build . --file Dockerfile --tag $DOCKER_HUB_REPO/canipay-fe:${{ steps.tag.outputs.tag }}
 
       - name: Push to docker hub repository
         run: |
-          docker push $DOCKER_HUB_REPO/canipay-fe:${{ steps.tag.outputs.tag }}
-          docker tag $DOCKER_HUB_REPO/canipay-fe:${{ steps.tag.outputs.tag }} $DOCKER_HUB_REPO/canipay-fe:latest
           docker push $DOCKER_HUB_REPO/canipay-fe:latest
+          docker tag $DOCKER_HUB_REPO/canipay-fe:latest $DOCKER_HUB_REPO/canipay-fe:${{ env.TAG }}
+          docker push $DOCKER_HUB_REPO/canipay-fe:${{ env.TAG }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,31 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v6
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        with:
+          config-name: release-drafter-config.yml
+        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Issue number
- close #34

### Description
- github action [release-drafter](https://github.com/release-drafter/release-drafter) workflow를 활용한 release 자동화 설정
- main branch PR 병합 시 label 따른 Features, Bug Fixes, Maintenance 자동 기능 정리
- main branch PR label에 따른 version 자동 설정
    - major: v1.0.0 증가
    - minor: v0.1.0 증가
    - patch(기본값): v0.0.1 증가
- PR(모든) 생성 시 브랜치 혹은 PR 타이틀에 따른 label 자동 설정
    | 자동 설정 label | branch | title (대소문자 구분 x) | 
    | -- | -- | -- | 
    | `feature` | `/feature\/.+/` | `/feature/i` | 
    | `bug` | `/bug\/.+/`, `/fix\/.+/`, `/hotfix\/.+/` | `/bug/i`, `/fix/i`, `/hotfix/i` | 
    | `chore` | `/chore\/.+/`, `/document\/.+/` | `/chore/i`, `/document/i` |

### Note
참고자료
- https://suho0303.tistory.com/55
- https://jiyeonseo.github.io/2022/10/15/github-action-release-drafter/