### PR TITLE
[Chore] - poi 클릭 시 zoom level 유지chore: poi 클릭 시 Zoom Level 변경 로직 제거 #39

### DIFF
--- a/src/hooks/useMapView.ts
+++ b/src/hooks/useMapView.ts
@@ -92,7 +92,6 @@ export const useMapView = (domName: string) => {
 
       mapView.getView().animate({
         center: newCenter,
-        zoom: LOCATION.zoom,
         duration,
       });
     },


### PR DESCRIPTION
### Issue number
- close #39

### Description
- poi 클릭 시 zoom level이 변경되어 사용성이 떨이지는 문제를 개선하였습니다.
- useMapView 커스텀 훅의 setCenter 메소드의 zoom level 설정 로직을 제거하였습니다.

### Note
- 