### PR TITLE
[Feature] - 매장 상세 페이지 이동 버튼 크기 확장

### DIFF
--- a/src/app/setting/page.tsx
+++ b/src/app/setting/page.tsx
@@ -11,6 +11,7 @@ import SlideToggle from '@/components/common/toggles/SlideToggle';
 import { usePreferences } from '@/components/contexts/PreferencesProvider';
 import { MESSAGE } from '@/constants/message';
 import { PAGE_PATH } from '@/constants/page';
+import { copyClipboard } from '@/utils/clipboard';
 
 function Setting() {
   const router = useRouter();
@@ -32,17 +33,15 @@ function Setting() {
     window.open('https://github.com/yws1502/canipay-fe');
   };
 
-  const handleCopyEmail = () => {
-    navigator.clipboard
-      .writeText('woosang0430@gmail.com')
-      .then(() => {
-        setIsCopied(true);
+  const handleCopyEmail = async () => {
+    const result = await copyClipboard('woosang0430@gmail.com');
 
-        setTimeout(() => {
-          setIsCopied(false);
-        }, 1500);
-      })
-      .catch(console.error);
+    if (result) {
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 1500);
+    } else {
+      alert('주소 복사에 실패하였습니다. 개발자에게 문의주세요.');
+    }
   };
 
   return (

--- a/src/components/stores/StoreDetail.tsx
+++ b/src/components/stores/StoreDetail.tsx
@@ -13,6 +13,7 @@ import { EXCEPTION_MESSAGE } from '@/constants/error';
 import { PAGE_PATH } from '@/constants/page';
 import { QUERY_KEY } from '@/constants/tanstackQuery';
 import { StoreInfo } from '@/types/store';
+import { copyClipboard } from '@/utils/clipboard';
 import TextButton from '../common/buttons/TextButton';
 import { useAsideToggle } from '../contexts/AsideToggleProvider';
 import { useMapController } from '../contexts/MapControllerProvider';
@@ -61,17 +62,15 @@ function StoreDetail({ initStoreInfo }: StoreDetailProps) {
     window.open(`${NAVER_MAP_URL}/${item}`, '_blank', 'noopener,noreferrer');
   };
 
-  const handleCopyAddress = (address: string) => {
-    navigator.clipboard
-      .writeText(address)
-      .then(() => {
-        setIsCopied(true);
+  const handleCopyAddress = async (address: string) => {
+    const result = await copyClipboard(address);
 
-        setTimeout(() => {
-          setIsCopied(false);
-        }, 1500);
-      })
-      .catch(console.error);
+    if (result) {
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 1500);
+    } else {
+      alert('주소 복사에 실패하였습니다. 개발자에게 문의주세요.');
+    }
   };
 
   return (

--- a/src/components/stores/StoreItem.tsx
+++ b/src/components/stores/StoreItem.tsx
@@ -70,7 +70,7 @@ function StoreItem({ storeInfo, className }: StoreItemProps) {
             query: searchParams.toString(),
           }}
           scroll={false}
-          className='truncate text-heading-3 text-gray-950 duration-300 ease-in-out hover:text-primary'
+          className='flex-1 truncate text-heading-3 text-gray-950 duration-300 ease-in-out hover:text-primary'
           title={storeInfo.name}
         >
           {storeInfo.name}


### PR DESCRIPTION
### Issue number
- close #45

### Description
- 기존에는 매장 타이틀 영역 클릭 시 상세 페이지가 열리도록 구현되어 있었습니다.
- 실제 사용자 피드백으로 클릭 되는 면적이 더 넓으면 좋겠다는 의견을 수용하여 버튼의 영역을 확장합니다.

### Note
- 