### PR TITLE
[Bug] - 무한 에러 페이지 이슈

### DIFF
--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,13 +1,17 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 
 interface ErrorPageProps {
-  error: Error;
+  error: Error & { digest?: string };
+  reset: () => void;
 }
 
-function ErrorPage({ error }: ErrorPageProps) {
-  console.error('error', error);
+function ErrorPage({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    console.error('error', error);
+  }, [error]);
+
   return (
     <section className='fixed inset-0 z-30 flex items-center justify-center bg-white'>
       <div className='flex flex-col items-center gap-5 text-center'>
@@ -18,6 +22,9 @@ function ErrorPage({ error }: ErrorPageProps) {
           문제가 계속된다면
           <strong className='text-primary'> 담당자에게 문의</strong>해주세요.
         </p>
+        <button type='button' onClick={reset}>
+          다시 시도
+        </button>
       </div>
     </section>
   );


### PR DESCRIPTION
### Issue number
- close #53

### Description
- 에러 발생 시 에러 페이지가 무한으로 리로딩 되는 이슈 발생 (메모리 사용량 증가)
- 해당 문제는 Global Error 컴포넌트 상단에서 console.error를 실행하여 발생한 이슈로 확인 됨
    - chat GPT에 의하면 Next.js에서 console.error는 내부적으로 에러 트래킹 도구에 연결이 되어 렌더 중 side-effect가 발생하여 무한 루프가 발생한다고 합니다. (관련된 이슈, 공식문서 그리고 자료를 찾아봤지만, 해당 내용에 관한 주제가 없었습니다.)
- 공식문서에서의 global-error 컴포넌트에성 console.error를 useEffect에서 실행하도록 되어 있어 코드를 수정하였습니다.

### Note
- 